### PR TITLE
Fix license of images to Apache-2.0

### DIFF
--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-all.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-all.bb
@@ -12,7 +12,7 @@
 # ********************************************************************************/
 
 SUMMARY = "A full quickstart image with all features and convenience tools enabled."
-LICENSE = "EPL"
+LICENSE = "Apache-2.0"
 
 # Debug tweaks
 IMAGE_FEATURES:append = " debug-tweaks"

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-full.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-full.bb
@@ -12,6 +12,7 @@
 # ********************************************************************************/
 
 SUMMARY = "A full quickstart image with all features and convenience tools enabled."
+LICENSE = "Apache-2.0"
 
 IMAGE_INSTALL = "packagegroup-core-boot ${CORE_IMAGE_EXTRA_INSTALL}"
 IMAGE_INSTALL:append = " kernel-image kernel-modules"
@@ -29,7 +30,6 @@ IMAGE_INSTALL:append = " packagegroup-sdv-examples"
 
 IMAGE_LINGUAS = " "
 
-LICENSE = "EPL"
 
 # Debug tweaks
 IMAGE_FEATURES:append = " debug-tweaks"

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-minimal.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-minimal.bb
@@ -12,6 +12,7 @@
 # ********************************************************************************/
 
 SUMMARY = "A minimal quickstart image with only core SDV packages installed."
+LICENSE = "Apache-2.0"
 
 IMAGE_INSTALL = "packagegroup-core-boot ${CORE_IMAGE_EXTRA_INSTALL}"
 IMAGE_INSTALL:append = " kernel-image kernel-modules"
@@ -21,7 +22,6 @@ IMAGE_INSTALL:append = " packagegroup-sdv-core"
 
 IMAGE_LINGUAS = " "
 
-LICENSE = "EPL"
 
 # Debug tweaks
 IMAGE_FEATURES:append = " debug-tweaks"

--- a/meta-leda-distro/recipes-sdv-distro/images/sdv-image-rescue.bb
+++ b/meta-leda-distro/recipes-sdv-distro/images/sdv-image-rescue.bb
@@ -12,6 +12,7 @@
 # ********************************************************************************/
 
 SUMMARY = "A minimalistic rescue-system image for a reset-device-to-factory-defaults showcase."
+LICENSE = "Apache-2.0"
 
 IMAGE_INSTALL = "packagegroup-core-boot ${CORE_IMAGE_EXTRA_INSTALL}"
 IMAGE_INSTALL:append = " kernel-image kernel-modules"
@@ -28,7 +29,6 @@ IMAGE_FEATURES:append = " empty-root-password"
 
 IMAGE_LINGUAS = " "
 
-LICENSE = "EPL"
 
 inherit core-image
 


### PR DESCRIPTION
Fixed the LICENSE definition of the SDV image definitions, as they were using the wrong license identifier (EPL) when in fact they are defined to be Apache-2.0 license.

Also testing the Auto-PR github bot for this pull request, which is supposed to auto-create PR's for target release branches if the PR gets labeled accordingly with `kirkstone` or `honister` labels