### PR TITLE
leda-utils: removed bash dependency

### DIFF
--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
@@ -14,9 +14,8 @@
 SUMMARY = "SDV Core Utilities"
 DESCRIPTION = "Core shell scripts for Eclipse Leda"
 
-# SRC_URI = "git://github.com/eclipse-leda/leda-utils;branch=main;protocol=https"
-SRC_URI = "git://github.com/SoftwareDefinedVehicle/leda-utils-fork;branch=main;protocol=https"
-SRCREV = "2d469041365b99cf72f7bd32726287c50f753f59"
+SRC_URI = "git://github.com/eclipse-leda/leda-utils;branch=main;protocol=https"
+SRCREV = "dfcba84c7865443dfbc157d289a49003ba46470a"
 
 # According to https://wiki.yoctoproject.org/wiki/License_Infrastructure_Interest_Group
 LICENSE = "Apache-2.0"

--- a/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
+++ b/meta-leda-components/recipes-sdv/eclipse-leda/leda-utils_git.bb
@@ -14,25 +14,24 @@
 SUMMARY = "SDV Core Utilities"
 DESCRIPTION = "Core shell scripts for Eclipse Leda"
 
-SRC_URI = "git://github.com/eclipse-leda/leda-utils;branch=main;protocol=https"
-SRCREV = "3b9cc95ff03b3fb682d4cce8ed695ed6612c9aae"
+# SRC_URI = "git://github.com/eclipse-leda/leda-utils;branch=main;protocol=https"
+SRC_URI = "git://github.com/SoftwareDefinedVehicle/leda-utils-fork;branch=main;protocol=https"
+SRCREV = "2d469041365b99cf72f7bd32726287c50f753f59"
 
 # According to https://wiki.yoctoproject.org/wiki/License_Infrastructure_Interest_Group
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-# Runtime Dependencies
-RDEPENDS:${PN} += " bash"
-
 do_install() {
     install -d ${D}${bindir}
     install -d ${D}${sysconfdir}/sdv
-    cp -R --no-dereference --preserve=mode,links -v ${WORKDIR}/git/src/bash/can-forward ${D}${bindir}
-    cp -R --no-dereference --preserve=mode,links -v ${WORKDIR}/git/src/bash/sdv-device-info ${D}${bindir}
-    cp -R --no-dereference --preserve=mode,links -v ${WORKDIR}/git/src/bash/sdv-health ${D}${bindir}
-    cp -R --no-dereference --preserve=mode,links -v ${WORKDIR}/git/src/bash/sdv-motd ${D}${bindir}
-    cp -R --no-dereference --preserve=mode,links -v ${WORKDIR}/git/src/bash/sdv-provision ${D}${bindir}
-    cp -R --no-dereference --preserve=mode,links -v ${WORKDIR}/git/src/bash/sdv.conf ${D}${sysconfdir}/sdv/
+
+    install -m 0755 ${WORKDIR}/git/src/sh/can-forward ${D}${bindir}
+    install -m 0755 ${WORKDIR}/git/src/sh/sdv-device-info ${D}${bindir}
+    install -m 0755 ${WORKDIR}/git/src/sh/sdv-health ${D}${bindir}
+    install -m 0755 ${WORKDIR}/git/src/sh/sdv-motd ${D}${bindir}
+    install -m 0755 ${WORKDIR}/git/src/sh/sdv-provision ${D}${bindir}
+    install -m 0644 ${WORKDIR}/git/src/sh/sdv.conf ${D}/etc/sdv/
 
     install -d ${D}${sysconfdir}/profile.d
     ln -sf ${bindir}/sdv-motd ${D}${sysconfdir}/profile.d/sdv-motd.sh


### PR DESCRIPTION
In this patch the SRC_URI and SRCREV for the fork is used, to allow a successful build.
This should be changed after the leda-utils changes have been merged into eclipse-leda.
